### PR TITLE
feat: Fetch and display products dynamically from Shopify collection

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,15 +13,21 @@ import { Testimonials } from "@/sections/HomePage/Testimonials";
 import { storeFront } from "../../utils";
 
 export default async function Home() {
-  const result = await storeFront(productQuery);
+  const variables = {
+    handle: "Contacts", // Replace with dynamic value as needed
+  };
 
-  const products = result.data.products.edges.map(({ node }: any) => ({
-    id: node.handle,
+  let result = await storeFront(productQuery, variables);
+
+  const data = result.data.collectionByHandle.products.edges;
+
+  const products = data.map(({ node }: any) => ({
+    id: node.id,
     name: node.title,
-    href: `/products/${node.handle}`,
+    href: `/products/${node.handle}`, // Assuming general product slug structure
     price: `$${parseFloat(node.priceRange.minVariantPrice.amount).toFixed(2)}`, // Format price
-    imageSrc: node.images.edges[0]?.node.transformedSrc || "",
-    imageAlt: node.images.edges[0]?.node.altText || "",
+    imageSrc: node.featuredImage.url,
+    imageAlt: node.featuredImage.altText,
   }));
 
   return (
@@ -43,32 +49,32 @@ export default async function Home() {
 const gql = String.raw;
 
 const productQuery = gql`
-  query Products {
-    products(first: 9) {
-      edges {
-        node {
-          title
-          handle
-          tags
-          priceRange {
-            minVariantPrice {
-              amount
-              currencyCode # Added currencyCode for completeness
+  query GetCollectionProducts($handle: String!) {
+    collectionByHandle(handle: $handle) {
+      title
+      description
+      products(first: 12) {
+        edges {
+          node {
+            id
+            title
+            handle
+            description
+            featuredImage {
+              url
+              altText
             }
-            maxVariantPrice {
-              amount
-              currencyCode # Added currencyCode for completeness
-            }
-          }
-          images(first: 1) {
-            edges {
-              node {
-                transformedSrc
-                altText
+            priceRange {
+              minVariantPrice {
+                amount
+                currencyCode
+              }
+              maxVariantPrice {
+                amount
+                currencyCode
               }
             }
           }
-          description
         }
       }
     }


### PR DESCRIPTION
This commit updates the homepage to fetch and display products dynamically from a specified Shopify collection using the `collectionByHandle` query.

- **Dynamic Product Fetching:** Modified the `Home` component to fetch products from a Shopify collection based on the `handle` variable.  A default "Contacts" collection is used.
- **GraphQL Query Update:** Updated the GraphQL query to `GetCollectionProducts` to fetch products within a collection, including `id`, `title`, `handle`, `description`, `featuredImage`, and `priceRange`.
- **Data Mapping:** Adjusted the data mapping to extract product information from the `collectionByHandle.products.edges` structure, using `featuredImage` for image source and alt text.
- **Variable Addition:** Added `variables` object to the `storeFront` function call to allow for dynamic querying of collections.