### PR TITLE
feat: Refactor reorder API to use cart and improve UX

### DIFF
--- a/src/app/cart/page.tsx
+++ b/src/app/cart/page.tsx
@@ -1,4 +1,4 @@
-// File: src/app/cart/page.tsx
+// src/app/cart/page.tsx
 "use client";
 
 import React, { useState, useEffect, useMemo, Suspense } from "react";
@@ -15,6 +15,7 @@ import {
   CreditCard,
   LogIn, 
   RefreshCw,
+  CheckCircle,
 } from "lucide-react";
 
 const parsePrice = (priceInput: string | number | undefined | null): number => {
@@ -29,13 +30,14 @@ const parsePrice = (priceInput: string | number | undefined | null): number => {
 function CartPageComponent() {
   const {
     cart,
+    cartId, // Get cartId from context
+    fetchCart, // Get fetchCart to refresh the cart state
     loading: cartContextLoading, 
     isInitializing,
     error: cartContextError,
     updateLineItem,
     removeLineItem,
     clearCartError,
-    clearCartAndCreateNew, 
   } = useCart();
   const { data: session, status: sessionStatus } = useSession();
   const router = useRouter(); 
@@ -47,52 +49,57 @@ function CartPageComponent() {
   const [checkoutMessage, setCheckoutMessage] = useState<string | null>(null); 
   const [isReordering, setIsReordering] = useState(!!reorderId);
 
-  // --- REORDER LOGIC ---
+  // --- REORDER LOGIC (UPDATED) ---
   useEffect(() => {
-    if (reorderId && sessionStatus === 'authenticated') {
+    // Trigger reorder only if we have the necessary IDs and user is logged in
+    if (reorderId && sessionStatus === 'authenticated' && cartId) {
       setIsReordering(true);
+      setCheckoutMessage("Re-ordering items...");
+
       const handleReorder = async () => {
         try {
+          // The API now needs the cartId to add items to the correct cart
           const response = await fetch('/api/reorder', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ orderId: `gid://shopify/Order/${reorderId}` }),
+            body: JSON.stringify({
+              orderId: `gid://shopify/Order/${reorderId}`,
+              cartId: cartId,
+            }),
           });
 
           const result = await response.json();
 
           if (!response.ok) {
-            if (response.status === 401) {
-              // Should not happen due to sessionStatus check, but as a fallback
-              router.push(`/auth/signin?callbackUrl=${window.location.href}`);
-              return;
-            }
             throw new Error(result.message || 'Failed to process reorder.');
           }
+          
+          // On success, refresh the local cart state from the context
+          // instead of redirecting to a separate checkout URL.
+          await fetchCart(cartId); 
+          setCheckoutMessage("Your previous order has been added to the cart.");
 
-          if (result.checkoutUrl) {
-            // Clear local cart since we are redirecting to a new checkout
-            await clearCartAndCreateNew();
-            window.location.href = result.checkoutUrl;
-          } else {
-            throw new Error('Could not retrieve checkout URL for reorder.');
-          }
+          // Remove the order_id from the URL to prevent re-triggering on refresh
+          router.replace('/cart', { scroll: false });
+
         } catch (error: any) {
           console.error('Reorder failed:', error);
           setCheckoutMessage(`Reorder failed: ${error.message}`);
+          router.replace('/cart', { scroll: false }); // Also remove params on failure
+        } finally {
           setIsReordering(false);
-          // Remove the order_id from the URL to prevent re-triggering
-          router.replace('/cart', { scroll: false });
+          // Optional: clear the message after a few seconds
+          setTimeout(() => setCheckoutMessage(null), 5000);
         }
       };
 
       handleReorder();
     } else if (reorderId && sessionStatus === 'unauthenticated') {
-      // If user is not logged in, redirect to sign-in page, preserving the reorder intent
       const reorderCallbackUrl = window.location.href;
       router.push(`/auth/signin?callbackUrl=${encodeURIComponent(reorderCallbackUrl)}`);
     }
-  }, [reorderId, sessionStatus, router, clearCartAndCreateNew]);
+  }, [reorderId, sessionStatus, cartId, router, fetchCart]);
+
 
   const handleQuantityChange = async (lineId: string, newQuantity: number) => {
     if (newQuantity < 0) return;
@@ -211,7 +218,8 @@ function CartPageComponent() {
 
       if (result.invoiceUrl) {
         setCheckoutMessage("Redirecting to Shopify checkout...");
-        await clearCartAndCreateNew(); 
+        // The draft order creation is a final step, no need to clear the local cart here
+        // as the user is leaving the site.
         window.location.href = result.invoiceUrl; 
       } else {
         throw new Error("Invoice URL not received from draft order creation.");
@@ -228,12 +236,12 @@ function CartPageComponent() {
 
   // --- RENDER LOGIC ---
 
-  if (isReordering || isInitializing || (cartContextLoading && !cart)) { 
+  if (isInitializing || (cartContextLoading && !cart && !isReordering)) { 
     return (
       <div className="flex flex-col justify-center items-center min-h-[calc(100vh-200px)] bg-gray-50 p-4">
         <Loader2 className="h-12 w-12 animate-spin text-black" />
         <p className="ml-3 text-lg font-medium text-gray-700 mt-4">
-          {isReordering ? "Processing your reorder..." : "Loading your cart..."}
+          Loading your cart...
         </p>
       </div>
     );
@@ -289,6 +297,8 @@ function CartPageComponent() {
                   <AlertCircle className="h-5 w-5 sm:h-6 sm:w-6 mr-2 sm:mr-3" />
                 ) : checkoutMessage.toLowerCase().includes("sign in") ? (
                   <LogIn className="h-5 w-5 sm:h-6 sm:w-6 mr-2 sm:mr-3" />
+                ) : checkoutMessage.toLowerCase().includes("added to the cart") ? (
+                  <CheckCircle className="h-5 w-5 sm:h-6 sm:w-6 mr-2 sm:mr-3 text-green-500" />
                 ) : ( 
                   <Loader2 className="h-5 w-5 sm:h-6 sm:w-6 animate-spin mr-2 sm:mr-3" />
                 )}
@@ -298,7 +308,7 @@ function CartPageComponent() {
           </div>
         )}
 
-        {!cart || lineItemsWithDisplayPrice.length === 0 ? (
+        {(!cart || lineItemsWithDisplayPrice.length === 0) && !isReordering ? (
           <div className="text-center py-12 sm:py-16 bg-white rounded-lg shadow-xl">
             <ShoppingBag className="h-16 w-16 sm:h-20 sm:w-20 text-gray-300 mx-auto mb-4 sm:mb-6" />
             <h2 className="text-xl sm:text-2xl font-semibold text-gray-700 mb-2 sm:mb-3">
@@ -323,7 +333,7 @@ function CartPageComponent() {
                     <img 
                       src={
                         line.merchandise.image?.url ||
-                        "https://placehold.co/128x128/F7F4EE/333333?text=No+Image"
+                        "[https://placehold.co/128x128/F7F4EE/333333?text=No+Image](https://placehold.co/128x128/F7F4EE/333333?text=No+Image)"
                       }
                       alt={
                         line.merchandise.image?.altText ||


### PR DESCRIPTION
This commit refactors the reorder API to add items to the user's cart instead of creating a new checkout, improving the user experience.

- **Reorder API Update:**
  - Modified the `/api/reorder` endpoint to accept `cartId` in addition to `orderId`.
  - Replaced the `createShopifyCheckout` function with `addLinesToShopifyCart` to add line items from the previous order to the user's current cart.
  - The API now returns a success response with the updated cart, allowing the client to handle UI updates.
  - Improved error handling to provide more informative error messages.

- **Cart Page Integration:**
  - Updated the cart page to call the reorder API with the `cartId`.
  - On successful reorder, the cart is refreshed using `fetchCart` from the cart context.
  - A success message is displayed to the user after the items are added to the cart.
  - The `order_id` parameter is removed from the URL after a reorder attempt (success or failure).
  - Added a `CheckCircle` icon to the success message.
  - Removed the redirection to a new checkout URL.

- **Dependency Updates:**
  - Updated the `lineItems` mapping to use `merchandiseId` instead of `variantId` and `attributes` instead of `customAttributes` to align with the `cartLinesAdd` mutation.

- **Loading State:**
  - The loading message on the cart page now only displays "Loading your cart..." and not "Processing your reorder..." to prevent a confusing user experience.