### PR TITLE
feat: Infer FocalProductType attribute during reorder if missing

### DIFF
--- a/src/components/EyeglassesPrescriptionModal.tsx
+++ b/src/components/EyeglassesPrescriptionModal.tsx
@@ -17,10 +17,6 @@ import { useCart } from "@/context/CartContext";
 import type { LensCustomizationData } from "@/sections/Products/EyeglassesModal";
 import { useRouter } from "next/navigation";
 
-// IMPORTANT: Ensure this is your actual Donation Product Variant GID
-const DONATION_PRODUCT_VARIANT_ID: any =
-  "gid://shopify/ProductVariant/46334706581757";
-
 export interface EyeglassRxDetails {
   prescriptionName?: string;
   shippingState?: string;
@@ -430,7 +426,6 @@ const EyeglassesPrescriptionModal: React.FC<
     }
   };
 
-
   const sphOptions = generateRangeOptions(-20, 20, 0.25, true);
   const cylOptions = generateRangeOptions(-10, 10, 0.25, true);
   const axisOptions = generateRangeOptions(0, 180, 1, false, "°");
@@ -568,13 +563,12 @@ const EyeglassesPrescriptionModal: React.FC<
               onChange={(e) => handleInputChange(sphField, e.target.value)}
               className="mt-1 w-full text-sm p-2 border-gray-300 rounded-md shadow-sm focus:ring-black focus:border-black"
             >
-              {" "}
-              <option value="">Select</option>{" "}
+              <option value="">Select</option>
               {sphOptions.map((o) => (
                 <option key={`${eye}-sph-${o}`} value={o}>
                   {o}
                 </option>
-              ))}{" "}
+              ))}
             </select>
           </div>
           <div>
@@ -590,13 +584,12 @@ const EyeglassesPrescriptionModal: React.FC<
               onChange={(e) => handleInputChange(cylField, e.target.value)}
               className="mt-1 w-full text-sm p-2 border-gray-300 rounded-md shadow-sm focus:ring-black focus:border-black"
             >
-              {" "}
-              <option value="">Select</option>{" "}
+              <option value="">Select</option>
               {cylOptions.map((o) => (
                 <option key={`${eye}-cyl-${o}`} value={o}>
                   {o}
                 </option>
-              ))}{" "}
+              ))}
             </select>
           </div>
           <div>
@@ -618,13 +611,12 @@ const EyeglassesPrescriptionModal: React.FC<
               disabled={isAxisDisabled}
               className="mt-1 w-full text-sm p-2 border-gray-300 rounded-md shadow-sm focus:ring-black focus:border-black disabled:bg-gray-200 disabled:cursor-not-allowed"
             >
-              {" "}
-              <option value="">Select</option>{" "}
+              <option value="">Select</option>
               {axisOptions.map((o) => (
                 <option key={`${eye}-axis-${o}`} value={o}>
                   {o}
                 </option>
-              ))}{" "}
+              ))}
             </select>
           </div>
           <div>
@@ -640,13 +632,12 @@ const EyeglassesPrescriptionModal: React.FC<
               onChange={(e) => handleInputChange(addField, e.target.value)}
               className="mt-1 w-full text-sm p-2 border-gray-300 rounded-md shadow-sm focus:ring-black focus:border-black"
             >
-              {" "}
-              <option value="">Select</option>{" "}
+              <option value="">Select</option>
               {addOptions.map((o) => (
                 <option key={`${eye}-add-${o}`} value={o}>
                   {o}
                 </option>
-              ))}{" "}
+              ))}
             </select>
           </div>
         </div>
@@ -863,8 +854,6 @@ const EyeglassesPrescriptionModal: React.FC<
           )}
           <div className="flex-grow"></div>
 
-          {currentStep === "initialChoice" &&
-            /* No "Next" button here; choices lead to actions */ null}
           {currentStep === "manualInput_patientInfo" && (
             <button
               onClick={handleNext}
@@ -891,12 +880,11 @@ const EyeglassesPrescriptionModal: React.FC<
               }
               className="px-4 py-2 text-sm font-medium bg-green-600 text-white rounded-md hover:bg-green-700 disabled:opacity-50 flex items-center"
             >
-              {" "}
               {isProcessingPageAction || cartLoading ? (
                 <Loader2 className="animate-spin h-4 w-4 mr-1.5" />
               ) : (
                 <CheckCircle size={16} className="mr-1.5" />
-              )}{" "}
+              )}
               Add to Cart
             </button>
           )}
@@ -910,7 +898,7 @@ const EyeglassesPrescriptionModal: React.FC<
                 <Loader2 className="animate-spin h-4 w-4 mr-1.5" />
               ) : (
                 <UploadCloud size={16} className="mr-1.5" />
-              )}{" "}
+              )}
               Upload & Add to Cart
             </button>
           )}

--- a/src/context/CartContext.tsx
+++ b/src/context/CartContext.tsx
@@ -153,10 +153,12 @@ export const CartProvider = ({ children }: CartProviderProps) => {
     currentLines.forEach(edge => {
       if (edge.node.merchandise.id === DONATION_PRODUCT_VARIANT_ID) return; 
 
-      const focalProductTypeAttr = edge.node.attributes.find(attr => attr.key === "FocalProductType");
-      if (focalProductTypeAttr?.value === "Eyeglasses") {
-        qualifyingEyeglassesCount++;
-      } else if (focalProductTypeAttr?.value === "ContactLenses") {
+      const isContactLens = edge.node.attributes.some(attr => attr.key === "FocalProductType" && attr.value === "ContactLenses");
+      const isEyeglasses = edge.node.attributes.some(attr => attr.key === "FocalProductType" && attr.value === "Eyeglasses");
+
+      if (isEyeglasses) {
+        qualifyingEyeglassesCount += edge.node.quantity;
+      } else if (isContactLens) {
         totalContactLensBoxes += edge.node.quantity;
       }
     });

--- a/src/sections/Products/ProductDetails/Hero.tsx
+++ b/src/sections/Products/ProductDetails/Hero.tsx
@@ -337,6 +337,7 @@ const Hero = ({ product }: any) => {
     }
   };
 
+
   const handleThumbnailClick = (src: string) => {
     setSelectedImage(src);
     setHasUserManuallySelectedImage(true);
@@ -673,22 +674,19 @@ const Hero = ({ product }: any) => {
               </div>
               {actionSuccess && (
                 <p className="mt-3 text-sm text-green-600 font-medium flex items-center">
-                  {" "}
                   <CheckCircle size={16} className="mr-1" /> Item(s) added to
-                  cart!{" "}
+                  cart!
                 </p>
               )}
               {actionError && (
                 <p className="mt-3 text-sm text-red-600 font-medium flex items-center">
-                  {" "}
-                  <AlertTriangle size={16} className="mr-1" /> {actionError}{" "}
+                  <AlertTriangle size={16} className="mr-1" /> {actionError}
                 </p>
               )}
               {cartContextError && !actionError && (
                 <p className="mt-3 text-sm text-red-600 font-medium flex items-center">
-                  {" "}
                   <AlertTriangle size={16} className="mr-1" /> Cart Error:{" "}
-                  {cartContextError}{" "}
+                  {cartContextError}
                 </p>
               )}
             </div>


### PR DESCRIPTION
This commit enhances the reorder functionality by inferring the `FocalProductType` attribute for line items from previous orders when it's missing. This ensures that products are correctly categorized (e.g., ContactLenses, Eyeglasses) when added to the cart during reordering.

- **Reorder API Route Update:**
  - Added logic to check for the existence of the `FocalProductType` attribute in the line item's custom attributes.
  - If the attribute is missing, the code attempts to infer the product type based on the presence of other common attributes:
    - If attributes contain keys related to eye prescriptions (e.g., "(OD)", "(OS)", "Eye"), the `FocalProductType` is set to "ContactLenses".
    - If attributes contain keys related to eyeglasses (e.g., "Rx Method", "Frame"), the `FocalProductType` is set to "Eyeglasses".
  - A warning message is logged to the console if a line item is skipped due to a missing variant ID.
  - The potentially modified attributes array, now including the inferred `FocalProductType` if applicable, is used when creating the new cart line item.