### PR TITLE
feat: Make insurance provider names clickable on how-to page

### DIFF
--- a/src/app/how-to-use-vision-insurance/page.tsx
+++ b/src/app/how-to-use-vision-insurance/page.tsx
@@ -333,7 +333,13 @@ const HowToUseInsurancePage = () => {
             </p>
             <div className="mt-4 flex flex-wrap justify-center items-center gap-x-6 sm:gap-x-8 gap-y-2 text-gray-500 font-semibold">
               {insuranceProviders.slice(0, 5).map((name) => (
-                <span key={name}>{name}</span>
+                <button
+                  key={name}
+                  onClick={() => handleProviderClick(name)}
+                  className="hover:text-black transition-colors duration-300"
+                >
+                  {name}
+                </button>
               ))}
             </div>
           </div>


### PR DESCRIPTION
This commit enhances the "How to Use Vision Insurance" page by making the insurance provider names clickable.

- Changed the insurance provider names from simple text to buttons.
- Implemented an `onClick` handler for each provider button, triggering the `handleProviderClick` function when clicked.
- Added basic styling to the buttons to indicate they are interactive, including a hover effect.