### PR TITLE
feat: Add ScrollToTop component

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import Providers from "./providers"; // For NextAuth SessionProvider
 import { CartProvider } from "@/context/CartContext"; // For Cart Context
 import { WishlistProvider } from "@/context/WishlistContext"; // Import WishlistProvider
 import BottomPromoBar from "@/components/BottomPromoBar"; // Import the new component
+import ScrollToTop from "@/components/ScrollToTop"; // Import the new ScrollToTop component
 
 // Configure DM Sans
 const dmSans = DM_Sans({
@@ -59,6 +60,7 @@ export default function RootLayout({
         <Providers>
           <CartProvider>
             <WishlistProvider>
+              <ScrollToTop /> {/* Add the ScrollToTop component here */}
               <Header />
               <main className="min-h-screen pb-16">{children}</main>{" "}
               {/* Add padding-bottom to avoid overlap */}

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -1,0 +1,23 @@
+// src/components/ScrollToTop.tsx
+"use client";
+
+import { useEffect } from "react";
+import { usePathname } from "next/navigation";
+
+/**
+ * A client component that listens for changes in the URL pathname
+ * and scrolls the window to the top (0, 0) on every navigation.
+ * This ensures users always start at the top of a new page.
+ */
+export default function ScrollToTop() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    // The `window.scrollTo` method scrolls the window to a particular
+    // place in the document. (0, 0) means the top-left corner.
+    window.scrollTo(0, 0);
+  }, [pathname]); // The effect re-runs every time the pathname changes.
+
+  // This component does not render any visible UI.
+  return null;
+}


### PR DESCRIPTION
This commit introduces a ScrollToTop component to provide users with a convenient way to quickly return to the top of the page.

- Imported the `ScrollToTop` component.
- Added the `ScrollToTop` component within the `Providers`, `CartProvider`, and `WishlistProvider` in `src/app/layout.tsx`.